### PR TITLE
Fix some bugs in "One spare empty desktop" mode

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -12,6 +12,13 @@ function isDesktopEmpty(desktop) {
     return true;
 }
 
+/**
+ * Closing focused desktops is allowed only if backHome is enabled
+ */
+function mayCloseDesktop(desktop) {
+    return workspace.currentDesktop != desktop || backHome;
+}
+
 function deleteDesktop(desktop) {
     if (workspace.currentDesktop == desktop && backHome){
         workspace.currentDesktop = workspace.desktops[0];
@@ -39,7 +46,7 @@ function balanceDesktops() {
 
     if (oneSpare) {
         for (var i = 0 ; i < workspace.desktops.length - 1 ; i++ ) {
-            if (isDesktopEmpty(workspace.desktops[i])){
+            if (isDesktopEmpty(workspace.desktops[i]) && mayCloseDesktop(workspace.desktops[i])){
                 deleteDesktop(workspace.desktops[i]);
             }
         }
@@ -48,7 +55,7 @@ function balanceDesktops() {
         }
     } else {
         for (var i = 0 ; i < workspace.desktops.length ; i++ ) {
-            if (isDesktopEmpty(workspace.desktops[i])){
+            if (isDesktopEmpty(workspace.desktops[i]) && mayCloseDesktop(workspace.desktops[i])){
                 deleteDesktop(workspace.desktops[i]);
             }   
         }

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -69,13 +69,13 @@ function connectSignals() {
     workspace.windowAdded.connect(window => {
         // Check if the window is normal.
         if (window !== null && window.normalWindow){
-            update;
+            update();
         }
     });
     workspace.windowRemoved.connect(window => {
         // Check if the window is normal.
         if (window !== null && window.normalWindow){
-            update;
+            update();
         }
     });
     workspace.desktopsChanged.connect(update);

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -21,11 +21,11 @@ function deleteDesktop(desktop) {
 
 function renameDesktops() {
     var n = 1;
-    for (var i = 1 ; i < workspace.desktops.length ; i++ ) {
+    for (var i = 0 ; i < workspace.desktops.length ; i++ ) {
         var d = workspace.desktops[i];
         if (/^Desktop\ ([0-9]{1,})$/.test(d.name)) {
-            n++;
             d.name = 'Desktop ' + n ;
+            n++;
         }
     }
 }
@@ -38,7 +38,7 @@ function balanceDesktops() {
     busy = true;
 
     if (oneSpare) {
-        for (var i = 1 ; i < workspace.desktops.length - 1 ; i++ ) {
+        for (var i = 0 ; i < workspace.desktops.length - 1 ; i++ ) {
             if (isDesktopEmpty(workspace.desktops[i])){
                 deleteDesktop(workspace.desktops[i]);
             }
@@ -47,10 +47,10 @@ function balanceDesktops() {
             workspace.createDesktop(workspace.desktops.length, '')
         }
     } else {
-        for (var i = 1 ; i < workspace.desktops.length ; i++ ) {
+        for (var i = 0 ; i < workspace.desktops.length ; i++ ) {
             if (isDesktopEmpty(workspace.desktops[i])){
                 deleteDesktop(workspace.desktops[i]);
-            }
+            }   
         }
     }
     renameDesktops();

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -19,6 +19,15 @@ function mayCloseDesktop(desktop) {
     return workspace.currentDesktop != desktop || backHome;
 }
 
+/**
+ * Should last desktop be closed because second to last is empty?
+ */
+function shouldCloseLastDesktop() {
+    return workspace.desktops.length >= 2 
+        && isDesktopEmpty(workspace.desktops[workspace.desktops.length - 2])
+        && mayCloseDesktop(workspace.desktops[workspace.desktops.length - 1]);
+}
+
 function deleteDesktop(desktop) {
     if (workspace.currentDesktop == desktop && backHome){
         workspace.currentDesktop = workspace.desktops[0];
@@ -50,7 +59,10 @@ function balanceDesktops() {
                 deleteDesktop(workspace.desktops[i]);
             }
         }
-        if (!isDesktopEmpty(workspace.desktops[workspace.desktops.length - 1])){
+
+        if (shouldCloseLastDesktop()) {
+            deleteDesktop(workspace.desktops[workspace.desktops.length - 1]);
+        } else if (!isDesktopEmpty(workspace.desktops[workspace.desktops.length - 1])){
             workspace.createDesktop(workspace.desktops.length, '')
         }
     } else {


### PR DESCRIPTION
* Fixed desktops not updated when opening or closing windows
* Fixed first desktop not closing after last window is closed
* Fixed desktop still closing if "Return to first desktop" is disabled. Now if this option is disabled active desktop will not close after last window is removed until user switches away from it
* Fixed two empty desktops appearing when closing last window on last desktops before spare (in other words when user is on last desktop with window and closes it previously desktop to the right (spare empty) remained and user could switch to it, but now it disappears because desktop user just closed window on is now the spare empty desktop)