### PR TITLE
option for minimum 2 empty desktops on startup

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -1,8 +1,12 @@
 var busy = false;
 var oneSpare = readConfig("oneSpare", false);
 var backHome = readConfig("backHome", false);
+var keepAtLeastTwoDesktops = readConfig("keepAtLeastTwoDesktops", false);
 
 function isDesktopEmpty(desktop) {
+    if (keepAtLeastTwoDesktops && workspace.desktops[0] == desktop) {
+        return false;
+    }
     for (var i in workspace.windowList()) {
         var window = workspace.windowList()[i];
         if (window.desktops.includes(desktop) && window.normalWindow && !window.skipTaskbar) {
@@ -54,7 +58,7 @@ function balanceDesktops() {
     busy = true;
 
     if (oneSpare) {
-        for (var i = 0 ; i < workspace.desktops.length - 1 ; i++ ) {
+        for (var i = keepAtLeastTwoDesktops ? 1 : 0 ; i < workspace.desktops.length - 1 ; i++ ) {
             if (isDesktopEmpty(workspace.desktops[i]) && mayCloseDesktop(workspace.desktops[i])){
                 deleteDesktop(workspace.desktops[i]);
             }

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -11,6 +11,9 @@
     <entry name="backHome" type="bool">
       <default>false</default>
     </entry>
+    <entry name="keepAtLeastTwoDesktops" type="bool">
+      <default>false</default>
+    </entry>
   </group>
 
 </kcfg>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -34,6 +34,16 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="QCheckBox" name="kcfg_keepAtLeastTwoDesktops">
+     <property name="text">
+      <string>Keep atleast 2 empty desktops on startup</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
This PR implements a feature to have atleast 2 empty when the user logs in.

This is how it looks

![image](https://github.com/user-attachments/assets/8a69d4dc-4c28-4d5c-bb00-b1b1fda68129)
